### PR TITLE
Check if selection has a fill or a border before trying to get the color

### DIFF
--- a/Color Copier.sketchplugin
+++ b/Color Copier.sketchplugin
@@ -63,10 +63,13 @@ function runColorCopier() {
 		case MSTextLayer:
     	fill = layer.textColor();
     break;
-
   	default:
-      fill = layer.style().fills().firstObject().color();
-      border = layer.style().borders().firstObject().color();
+      if (layer.style().fills().count() > 0) {
+        fill = layer.style().fills().firstObject().color();
+      }
+      if (layer.style().borders() > 0) {
+        border = layer.style().borders().firstObject().color();
+      }
     break;
 
 	}


### PR DESCRIPTION
This fixes an issue where the plugin fails to work for objects without a border.

You should probably do a bit of error checking, as the plugin currently tries to run with objects without a fill.
